### PR TITLE
Add project skeleton for A1

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,1 @@
+**/dist-newstyle

--- a/Assignments/a1/README.md
+++ b/Assignments/a1/README.md
@@ -1,0 +1,16 @@
+# CS3MI3 Assignment 1
+
+This is a project skeleton for assignment 1 of CS3MI3. For a description of
+the assignment, see the assignment section in avenue.
+
+# Where do I write my code?
+
+Please write the code for `evalExpr` in `src/A1/Eval.hs`, and your tests
+in `test/Main.hs`. We have provided a pair of example `HUnit` tests for you; all
+other tests should follow this pattern. Make sure to remove these two example tests before
+submission!
+
+# How do I compile, run, and test my code?
+
+To compile your code, run `cabal build`. You can run GHCi with `cabal repl`; this
+will automatically load `A1.Eval` for you! Tests can be run with `cabal test`.

--- a/Assignments/a1/a1.cabal
+++ b/Assignments/a1/a1.cabal
@@ -1,0 +1,33 @@
+cabal-version:      3.0
+name:               a1
+version:            0.1.0.0
+license:            NONE
+build-type:         Simple
+
+common warnings
+    ghc-options: -Wall
+
+library
+  hs-source-dirs:
+      src
+  exposed-modules:
+    -- If you want to add more files, add them here!
+    A1.Eval
+  build-depends:
+    base ^>=4.17.1.0
+  default-language:
+    GHC2021
+
+test-suite a1-test
+  type:
+    exitcode-stdio-1.0
+  hs-source-dirs:
+    test
+  main-is:
+    Main.hs
+  build-depends:
+    a1,
+    base ^>=4.17.1.0,
+    HUnit ^>=1.6
+  default-language:
+    GHC2021

--- a/Assignments/a1/hie.yaml
+++ b/Assignments/a1/hie.yaml
@@ -1,0 +1,7 @@
+cradle:
+  cabal:
+    - path: "src"
+      component: "lib:a1"
+
+    - path: "test"
+      component: "a1:test:a1-test"

--- a/Assignments/a1/src/A1/Eval.hs
+++ b/Assignments/a1/src/A1/Eval.hs
@@ -1,0 +1,27 @@
+-- | Evaluator for Assignment 1.
+module A1.Eval where
+
+data Expr =
+    EInt Integer
+  | ECh Char
+  | EBool Bool
+  | EString String
+  --
+  | EAdd Expr Expr    -- addition of integers
+  | EMul Expr Expr    -- multiplication of integers
+  | ENeg Expr         -- negation of integers
+  | ECat Expr Expr    -- concatenation of strings
+  | ECons Char Expr   -- adding a character at the start of a string
+  | EAnd Expr Expr    -- AND of two booleans
+  | EXor Expr Expr    -- XOR of two booleans
+  | EIf Expr Expr Expr -- if-then-else
+  | EShowInt Expr      -- render an integer as a string
+
+data Val =
+    VInt Integer
+  | VBool Bool
+  | VString String
+  | VError             -- something went wrong
+
+evalExpr :: Expr -> Val
+evalExpr = error "TODO: Your code lives here!"

--- a/Assignments/a1/test/Main.hs
+++ b/Assignments/a1/test/Main.hs
@@ -1,0 +1,25 @@
+-- | Tests for Assignment 1.
+module Main where
+
+import A1.Eval
+
+import Test.HUnit
+import System.Exit
+
+-- These tests are meant to serve as examples for how to use 'HUnit'.
+-- !!!! THESE DO NOT COUNT TOWARDS YOUR MARKS, AND SHOULD BE REMOVED BEFORE SUBMISSION !!!!
+-- TODO: Delete these tests, and write your own for 'evalExpr'.
+a1Tests :: Test
+a1Tests = TestList
+  [ TestCase (assertEqual "This is a working test" (reverse "hello") "olleh")
+  , TestCase (assertEqual "This is a broken test" (1 + 1) 3)
+  ]
+
+-- Run the test suite. Please do not touch this!
+main :: IO ()
+main = do
+    counts <- runTestTT a1Tests
+    if errors counts + failures counts == 0 then
+      exitSuccess
+    else
+      exitFailure


### PR DESCRIPTION
This PR adds a simple project skeleton for A1, which includes scaffolding for `HUnit`, as well as a pair of example tests.